### PR TITLE
Fill frame in background thread

### DIFF
--- a/CMIOMinimalSample/Stream.h
+++ b/CMIOMinimalSample/Stream.h
@@ -27,6 +27,8 @@ NS_ASSUME_NONNULL_BEGIN
 
 @property CMIOStreamID objectId;
 
+- (instancetype _Nonnull)init;
+
 - (CMSimpleQueueRef)copyBufferQueueWithAlteredProc:(CMIODeviceStreamQueueAlteredProc)alteredProc alteredRefCon:(void *)alteredRefCon;
 
 - (void)startServingFrames;


### PR DESCRIPTION
I made `Stream.fillFrame` run in a background thread, using `dispatch_source`.
It fixes CMIOMinimalSample may be laggy and not show frames in Google Chrome.

(This is a backport from [SimpleDALPlugin](https://github.com/seanchas116/SimpleDALPlugin/blob/master/SimpleDALPlugin/Stream.swift#L67).)
