### PR TITLE
Fix header import on case-sensitive filesystems

### DIFF
--- a/CMIOMinimalSample/PlugIn.mm
+++ b/CMIOMinimalSample/PlugIn.mm
@@ -9,7 +9,7 @@
 
 #import "PlugIn.h"
 
-#import <CoreMediaIO/CMIOHardwarePlugin.h>
+#import <CoreMediaIO/CMIOHardwarePlugIn.h>
 
 #import "Logging.h"
 

--- a/CMIOMinimalSample/PlugInMain.mm
+++ b/CMIOMinimalSample/PlugInMain.mm
@@ -7,7 +7,7 @@
 //  CMIOMinimalSample is free software, and use is bound by the terms
 //  set out in the LICENSE file distributed with this project.
 
-#import <CoreMediaIO/CMIOHardwarePlugin.h>
+#import <CoreMediaIO/CMIOHardwarePlugIn.h>
 
 #import "PlugInInterface.h"
 #import "Logging.h"


### PR DESCRIPTION
Header file import has a typo, resulting in a failed build on case-sensitive filesystems.